### PR TITLE
Added option for merging conflicting configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Default value: `['js', 'coffee']`
 
 Valid file extensions to import properties from within `configDir`.
 
+#### options.mergeConfig
+Type: `Boolean`
+Default value: `true`
+
+If multiple configurations are found for the same task, they will be merged by default. If set to false, new task configurations will override previous ones.
+
 ### Usage Example
 
 #### Gruntfile.js

--- a/src/tasks/config_dir.coffee
+++ b/src/tasks/config_dir.coffee
@@ -8,6 +8,8 @@ module.exports = (grunt, options, errHandler) ->
   res._defaultOptions =
     configDir: path.resolve('grunt')
     fileExtensions: ['js', 'coffee']
+    mergeConfig: true
+
   grunt.util._.extend res.options, res._defaultOptions, options
 
   res.fileExtensionPattern = res.options.fileExtensions.join '|'
@@ -19,9 +21,17 @@ module.exports = (grunt, options, errHandler) ->
   res.walk = walk.walkSync(res.options.configDir, (baseDir, filename, stat) ->
     if match = filename.match(res.regexp)
 
-      grunt.config.set match[1], require(
+      task = match[1]
+      taskConfig = {}
+      taskConfig[task] = require(
         path.join(baseDir, filename)
       )(grunt)
+
+
+      if res.options.mergeConfig
+        grunt.config.merge taskConfig
+      else
+        grunt.config.set task, taskConfig[task]
 
       res.files.push
         baseDir: baseDir

--- a/tasks/config_dir.js
+++ b/tasks/config_dir.js
@@ -12,7 +12,8 @@
     };
     res._defaultOptions = {
       configDir: path.resolve('grunt'),
-      fileExtensions: ['js', 'coffee']
+      fileExtensions: ['js', 'coffee'],
+      mergeConfig: true
     };
     grunt.util._.extend(res.options, res._defaultOptions, options);
     res.fileExtensionPattern = res.options.fileExtensions.join('|');
@@ -20,9 +21,16 @@
     res.files = [];
     res.ignored = [];
     res.walk = walk.walkSync(res.options.configDir, function(baseDir, filename, stat) {
-      var match, msg;
+      var match, msg, task, taskConfig;
       if (match = filename.match(res.regexp)) {
-        grunt.config.set(match[1], require(path.join(baseDir, filename))(grunt));
+        task = match[1];
+        taskConfig = {};
+        taskConfig[task] = require(path.join(baseDir, filename))(grunt);
+        if (res.options.mergeConfig) {
+          grunt.config.merge(taskConfig);
+        } else {
+          grunt.config.set(task, taskConfig[task]);
+        }
         res.files.push({
           baseDir: baseDir,
           filename: filename,


### PR DESCRIPTION
Hello,
I'm managing a large project with multiple Gruntfiles, which in turn are loaded from a master Gruntfile

I needed to add an option to merge configurations, in order to avoid clobbering when two configs by the same name are found.

Eg: If I have:

**GruntfileA -> foo/clean.js**

``` js
return {
sub_task1:[stuff]
}
```

and
**GruntfileB -> bar/clean.js**

``` js
return {
sub_task2:[stuff]
}
```

The second will clobber the first.
