### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Default value: `['js', 'coffee']`
 
 Valid file extensions to import properties from within `configDir`.
 
+#### options.mergeConfig
+Type: `Boolean`
+Default value: `true`
+
+If multiple configurations are found for the same task, they will be merged by default. If set to false, new task configurations will override previous ones.
+
 ### Usage Example
 
 #### Gruntfile.js

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-bump": "0.0.13"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"

--- a/src/tasks/config_dir.coffee
+++ b/src/tasks/config_dir.coffee
@@ -8,6 +8,8 @@ module.exports = (grunt, options, errHandler) ->
   res._defaultOptions =
     configDir: path.resolve('grunt')
     fileExtensions: ['js', 'coffee']
+    mergeConfig: true
+
   grunt.util._.extend res.options, res._defaultOptions, options
 
   res.fileExtensionPattern = res.options.fileExtensions.join '|'
@@ -19,9 +21,17 @@ module.exports = (grunt, options, errHandler) ->
   res.walk = walk.walkSync(res.options.configDir, (baseDir, filename, stat) ->
     if match = filename.match(res.regexp)
 
-      grunt.config.set match[1], require(
+      task = match[1]
+      taskConfig = {}
+      taskConfig[task] = require(
         path.join(baseDir, filename)
       )(grunt)
+
+
+      if res.options.mergeConfig
+        grunt.config.merge taskConfig
+      else
+        grunt.config.set task, taskConfig[task]
 
       res.files.push
         baseDir: baseDir

--- a/tasks/config_dir.js
+++ b/tasks/config_dir.js
@@ -12,7 +12,8 @@
     };
     res._defaultOptions = {
       configDir: path.resolve('grunt'),
-      fileExtensions: ['js', 'coffee']
+      fileExtensions: ['js', 'coffee'],
+      mergeConfig: true
     };
     grunt.util._.extend(res.options, res._defaultOptions, options);
     res.fileExtensionPattern = res.options.fileExtensions.join('|');
@@ -20,9 +21,16 @@
     res.files = [];
     res.ignored = [];
     res.walk = walk.walkSync(res.options.configDir, function(baseDir, filename, stat) {
-      var match, msg;
+      var match, msg, task, taskConfig;
       if (match = filename.match(res.regexp)) {
-        grunt.config.set(match[1], require(path.join(baseDir, filename))(grunt));
+        task = match[1];
+        taskConfig = {};
+        taskConfig[task] = require(path.join(baseDir, filename))(grunt);
+        if (res.options.mergeConfig) {
+          grunt.config.merge(taskConfig);
+        } else {
+          grunt.config.set(task, taskConfig[task]);
+        }
         res.files.push({
           baseDir: baseDir,
           filename: filename,


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
